### PR TITLE
Run some of the queries in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You'll need to [install Xata](https://xata.io/docs/getting-started/installation)
 - Remove the Xata files that point to our database
   - `rm -rf .xata utils/xata.ts .xatarc`
 - `pnpm install`
-- Run `xata init --schema schema.json --codegen=utils/xata.ts` to create a new database with the necessary schema
+- Run `xata init --schema schema.json --codegen=utils/xata.ts` to create a new database with the necessary schema. When creating the database, choose `us-east-1` as the region. If you pick another region, you will need to add it to `next.config.js`.
 - `pnpm run dev` to load the site at http://localhost:3000
 - Add images either through the application, or through your database UI at https://app.xata.io
 


### PR DESCRIPTION
Started with a simpler optimization to see if/how much it helps.

* request the page, the count, and the tags in parallel.
* uses summarize for the total count instead of aggregate. This is not really an optimisation but it's better because summarize is guaranteed to be consistent.
* added timing logging so we see how much things take in vercel.