### PR TITLE
Allow bootstrap command to allow for a source db

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky install",
     "seed": "node scripts/seed.mjs",
     "cleanup": "node scripts/cleanup.mjs",
-    "bootstrap": "node scripts/cleanup.mjs --force && xata init --schema schema.json --codegen=utils/xata.ts && node scripts/seed.mjs",
+    "bootstrap": "node scripts/bootstrap.mjs",
     "xata:one-click": "pnpm install && node scripts/cleanup.mjs --force && node scripts/one-click.mjs && node scripts/seed.mjs"
   },
   "dependencies": {

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,12 +1,15 @@
 import { execSync } from 'child_process';
 
 const args = process.argv.slice(2);
-let dbArg = args.find((arg) => arg.startsWith('--db='));
+const dbIndex = args.indexOf('--db');
+let dbValue = null;
+
+if (dbIndex !== -1 && dbIndex < args.length - 1) {
+  dbValue = args[dbIndex + 1];
+}
 
 let cmd = 'node scripts/cleanup.mjs --force && xata init --schema schema.json --codegen=utils/xata.ts';
-if (dbArg) {
-  // Extracting the value from --db=value
-  const dbValue = dbArg.split('=')[1];
+if (dbValue) {
   cmd += ` --db ${dbValue}`;
 }
 cmd += ' && node scripts/seed.mjs';

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,0 +1,9 @@
+import { execSync } from 'child_process';
+
+let cmd = 'node scripts/cleanup.mjs --force && xata init --schema schema.json --codegen=utils/xata.ts';
+if (process.env.npm_config_db) {
+  cmd += ` --db ${process.env.npm_config_db}`;
+}
+cmd += ' && node scripts/seed.mjs';
+
+execSync(cmd, { stdio: 'inherit' });

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,8 +1,13 @@
 import { execSync } from 'child_process';
 
+const args = process.argv.slice(2);
+let dbArg = args.find((arg) => arg.startsWith('--db='));
+
 let cmd = 'node scripts/cleanup.mjs --force && xata init --schema schema.json --codegen=utils/xata.ts';
-if (process.env.npm_config_db) {
-  cmd += ` --db ${process.env.npm_config_db}`;
+if (dbArg) {
+  // Extracting the value from --db=value
+  const dbValue = dbArg.split('=')[1];
+  cmd += ` --db ${dbValue}`;
 }
 cmd += ' && node scripts/seed.mjs';
 

--- a/scripts/cleanup.mjs
+++ b/scripts/cleanup.mjs
@@ -1,17 +1,16 @@
-import { execSync } from 'child_process';
+//@ts-check
+import { exec } from 'node:child_process';
 
-const args = process.argv.slice(2);
-const dbIndex = args.indexOf('--db');
-let dbValue = null;
-
-if (dbIndex !== -1 && dbIndex < args.length - 1) {
-  dbValue = args[dbIndex + 1];
+if (process.argv.length < 3 || process.argv[2] !== '--force') {
+  console.log(`❯ ☢️ This deletes all Xata generated files, including the schema history!`);
+  console.log(`❯ ⚠️ Please run this command with the --force flag to continue.`);
+  process.exit(0);
 }
 
-let cmd = 'node scripts/cleanup.mjs --force && xata init --schema schema.json --codegen=utils/xata.ts';
-if (dbValue) {
-  cmd += ` --db ${dbValue}`;
+try {
+  exec(`rm -rf ./.xata ./utils/xata.ts ./.xatarc`);
+} catch {
+  console.warn('Cleanup gone wrong.');
 }
-cmd += ' && node scripts/seed.mjs';
 
-execSync(cmd, { stdio: 'inherit' });
+console.log(`❯ ✅ Cleanup complete.`);

--- a/scripts/cleanup.mjs
+++ b/scripts/cleanup.mjs
@@ -1,16 +1,17 @@
-//@ts-check
-import { exec } from 'node:child_process';
+import { execSync } from 'child_process';
 
-if (process.argv.length < 3 || process.argv[2] !== '--force') {
-  console.log(`❯ ☢️ This deletes all Xata generated files, including the schema history!`);
-  console.log(`❯ ⚠️ Please run this command with the --force flag to continue.`);
-  process.exit(0);
+const args = process.argv.slice(2);
+const dbIndex = args.indexOf('--db');
+let dbValue = null;
+
+if (dbIndex !== -1 && dbIndex < args.length - 1) {
+  dbValue = args[dbIndex + 1];
 }
 
-try {
-  exec(`rm -rf ./.xata ./utils/xata.ts ./.xatarc`);
-} catch {
-  console.warn('Cleanup gone wrong.');
+let cmd = 'node scripts/cleanup.mjs --force && xata init --schema schema.json --codegen=utils/xata.ts';
+if (dbValue) {
+  cmd += ` --db ${dbValue}`;
 }
+cmd += ' && node scripts/seed.mjs';
 
-console.log(`❯ ✅ Cleanup complete.`);
+execSync(cmd, { stdio: 'inherit' });


### PR DESCRIPTION
This will allow us to conditionally pass the DB to the bootstrap command. We'll use this in instructions within the application onboarding to make things easy.