### PR TITLE
Make file column public by default in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -29,7 +29,9 @@
         {
           "name": "image",
           "type": "file",
-          "defaultPublicAccess": true
+          "file": {
+            "defaultPublicAccess": true
+          }
         }
       ],
       "revLinks": [

--- a/schema.json
+++ b/schema.json
@@ -28,7 +28,8 @@
         },
         {
           "name": "image",
-          "type": "file"
+          "type": "file",
+          "defaultPublicAccess": true
         }
       ],
       "revLinks": [


### PR DESCRIPTION
Related to a backend change that allows the schema to default to public for File columns.

When running `pnpm run bootstrap` (**against a new db!**) the database created should make new records default to the File column having public access.